### PR TITLE
[Bug Fix] remove libpython linking dependency

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
     swig_add_library(pywraps2 LANGUAGE python SOURCES s2.i)
 endif()
 
-swig_link_libraries(pywraps2 ${PYTHON_LIBRARIES} s2)
+swig_link_libraries(pywraps2 s2)
 enable_testing()
 add_test(NAME pywraps2_test COMMAND
          ${PYTHON_EXECUTABLE}


### PR DESCRIPTION
We had some trouble in deployment since the current _pywraps2.so links against libpython3.6m.so, which is not available in some of our environments. However, libpython is not actually used  in _pywraps2.so. This PR will remove the  libpython3.6m.so symbol from _pywarps2.so. 